### PR TITLE
Update beacons.md

### DIFF
--- a/beacons.md
+++ b/beacons.md
@@ -16,7 +16,7 @@ has_children: true
 | iPhones              |                                             | [Pair to retrieve IRK](/beacons/apple)
 | Apple Watches        |                                             | [Use iCloud keychain to get IRK](/beacons/apple)
 | Wear OS Smartwatches |                                             | [Must use HA companion app](/beacons/android)
-| Tiles                | [amazon](https://amzn.to/3h77T5f)           | These work great, but update somewhat slow
+| Tiles                | [amazon](https://amzn.to/3h77T5f)           | These work great, but update somewhat slow, need to close any phone app accessing the tiles
 | Blue Charm Beacons   | [amazon](https://amzn.to/2YGdA3w)           | Configure as iBeacon or eddystone, don't enable both at the same time
 | Generic BTLE Beacons |                                             | Anything that follows the iBeacon or Eddystone standards
 | musegear finder 2    | [musegear](https://shop.musegear-finder.net/collections/finder-2) | Must be connected once with the associated app.


### PR DESCRIPTION
According to 
https://www.reddit.com/r/homeassistant/comments/asq2gn/anyone_using_the_tile_pro_as_a_ble_beacon/ the tiles bind to the phone when app is running and are no longer showing up in the fingerprints